### PR TITLE
Support passing method and lambda references to `to_table_display`

### DIFF
--- a/README
+++ b/README
@@ -75,6 +75,9 @@ Example
 |  2 | Blog the plugin      | 2009-04-05 |                                |
 +----+----------------------+------------+--------------------------------+
 
+# It is possible to use objects that respond to #call -- such as methods or procs -- to set up columns. They will be
+# passed the record as their sole argument. If these have names (as with methods), those will be used as the headers.
+# Otherwise, the default `to_s` behaviour will be used.
 
 # Note that in all cases, values descending from Numeric are right-aligned, while all other values are left-aligned.
 

--- a/test/table_display_test.rb
+++ b/test/table_display_test.rb
@@ -188,7 +188,36 @@ END
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+------------+------------------------+
 END
   end
-  
+
+  test "#to_table_display also shows any named callables given as columns" do
+    instrument = Object.new.tap { |o| o.define_singleton_method(:sample) { |record| "(id #{record.id})" } }
+
+    assert_equal <<END.strip, @project.tasks.to_table_display('id', :due_on, :completed?, instrument.method(:sample)).join("\n")
++----+------------------+------------+----------+
+| id | due_on           | completed? | sample   |
++----+------------------+------------+----------+
+|  1 | Wed, 25 Mar 2009 | true       | "(id 1)" |
+|  2 | Sun, 05 Apr 2009 | false      | "(id 2)" |
++----+------------------+------------+----------+
+END
+  end
+
+  test "#to_table_display also shows any unnamed callables given as columns" do
+    instrument = Object.new.tap do |object|
+      object.define_singleton_method(:call) { |record| "(id #{record.id})" }
+      object.define_singleton_method(:to_s) { "arbitrary to_s" }
+    end
+
+    assert_equal <<END.strip, @project.tasks.to_table_display('id', :due_on, :completed?, instrument).join("\n")
++----+------------------+------------+----------------+
+| id | due_on           | completed? | arbitrary to_s |
++----+------------------+------------+----------------+
+|  1 | Wed, 25 Mar 2009 | true       | "(id 1)"       |
+|  2 | Sun, 05 Apr 2009 | false      | "(id 2)"       |
++----+------------------+------------+----------------+
+END
+  end
+
   test "#to_table_display shows the #to_s format rather than the #inspect format when :inspect => false is set" do
     assert_equal <<END.strip, @project.tasks.to_table_display(:inspect => false).join("\n")
 +----+------------+----------------------+------------+---------------------------+---------------------------+---------------------------+


### PR DESCRIPTION
I frequently make use of `to_table_display` during development and debugging, and occasionally find myself wanting to augment the table with arbitrary calculated columns to confirm my suspicions. Although I have sometimes solved this by live-defining the calculation method onto the objects in question, this is not a strategy I'm generally inclined to.

This changeset allows passing arity-1 lambdas – and more generally anything that responds to `#call` – to the `to_table_display` method, and using this to generate additional columns. It defers to the `name` method for headers when these callables provide it (such as with methods). I considered using blocks to support this behaviour, but given that Ruby supports only the one block, it seemed appropriate to keep that syntax reserved.
