### PR TITLE
Decide inline on calling to_table_display

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 Table Display
 =============
 
-Adds support for displaying your ActiveRecord tables, named scopes, collections, or
+Displays ActiveRecord tables, named scopes, collections, hashes, or
 plain arrays in a table view when working in rails console, shell, or email template.
 
-`Enumerable#to_table_display` returns the printable strings; `Object#pt` calls `#to_table_display`
-on its first argument and puts out the result.
+`TableDisplay.to_table_display` returns the printable strings; `Object#pt` calls
+`TableDisplay.to_table_display` and puts out the result.
 
 Columns you haven't loaded (eg. from using `:select`) are omitted, and derived/calculated
 columns (eg. again, from using `:select`) are added.
 
-Both `#to_table_display` and `Object#pt` methods take `:only`, `:except`, and `:methods` which 
+Both `TableDisplay.to_table_display` and `Object#pt` methods take `:only`, `:except`, and `:methods` which 
 change what attributes/methods are output, like they do on the `#to_xml` method.
 
 The normal output uses `#inspect` on the data values to make them printable, so you can
@@ -23,7 +23,7 @@ Example
 
 You can call the `to_table_display` method:
 
-    >> puts Project.find(31).tasks.to_table_display
+    >> puts TableDisplay.tasks.to_table_display(Project.find(31))
     +----+------------+------------------------+------------------+--------------------------------+--------------------------------+--------------------------------+
     | id | project_id | description            | due_on           | completed_at                   | created_at                     | updated_at                     |
     +----+------------+------------------------+------------------+--------------------------------+--------------------------------+--------------------------------+
@@ -45,7 +45,7 @@ Or equivalently, use `pt` (like `pp`, but in a table):
 Like `to_xml`, you can pass a `:methods` option to add the output methods on your models, and you
 can pass `:only` or `:except` to (respectively) show only certain columns or show all except certain columns:
 
-    >> puts Customer.find(31).purchases.to_table_display(:only => [:id, :description], :methods => [:met_due_date?])
+    >> puts TableDisplay.to_table_display(Customer.find(31).purchases, :only => [:id, :description], :methods => [:met_due_date?])
     +----+------------------------+---------------+
     | id | description            | met_due_date? |
     +----+------------------------+---------------+
@@ -65,7 +65,7 @@ can pass `:only` or `:except` to (respectively) show only certain columns or sho
 
 There's a convenient equivalent syntax for displaying an ordered list of columns, like `:only` and `:methods`:
 
-    >> puts Customer.find(31).purchases.to_table_display :id, :description, :met_due_date?
+    >> puts TableDisplay.to_table_display(Customer.find(31).purchases, :id, :description, :met_due_date?)
 
 which provides:
 
@@ -94,4 +94,4 @@ Thanks
 ------
 * Michael Fowler (@mkrfowler)
 
-Copyright (c) 2009-2018 Will Bryant, Sekuda Ltd, released under the MIT license
+Copyright (c) 2009-2020 Will Bryant, Sekuda Ltd, released under the MIT license

--- a/lib/table_display.rb
+++ b/lib/table_display.rb
@@ -1,5 +1,5 @@
 module TableDisplay
-  def to_table_display(*args)
+  def self.to_table_display(target, *args)
     options = args.last.is_a?(Hash) ? args.pop : {}
     extra_entries = args.collect { |arg| arg.respond_to?(:call) ? arg : arg.to_s }
     extra_entries += Array(options.delete(:methods)) if options[:methods]
@@ -9,17 +9,17 @@ module TableDisplay
     except_attributes = (except_attributes + except_attributes.collect(&:to_s)).uniq if except_attributes.present? # we have to keep string and symbol arguments separate for hashes, which may not have 'indifferent access'
     display_inspect = options.nil? || !options.has_key?(:inspect) || options.delete(:inspect)
     raise "unknown options passed to to_table_display: #{options.keys.to_sentence}" unless options.blank?
-    
+
     column_lengths = ActiveSupport::OrderedHash.new
-    
+
     if only_attributes
       # we've been given an explicit list of attributes to display
       only_attributes.each {|attribute| column_lengths[attribute] = 0}
     else
       # find all the attribute names
-      each do |record|
+      target.each do |record|
         next if record.nil?
-      
+
         # ActiveRecord's #attributes implementation iterates over #attribute_names adding a duped value to the output hash for each entry, so
         # it's actually more expensive to get the keys and values in one go using #attributes than it is for us to work off #attribute_names ourselves.
         if record.respond_to?(:attribute_names)
@@ -36,7 +36,7 @@ module TableDisplay
           # hopefully something like a hash
           attribute_names = record.keys
         end
-      
+
         if attribute_names.any? {|name| column_lengths[name].nil?} # optimisation, in most use cases all records will have the same type and the same attributes, so we needn't run this for each - but we do handle varying attribute lists, and attributes that are not columns on the model (calculated columns etc.)
           # for ActiveRecord classes, we look at the .columns explicitly so we can keep them in the right order
           columns_to_check = record.is_a?(ActiveRecord::Base) ? ((record.class.columns.collect(&:name) & attribute_names) + attribute_names).uniq : attribute_names
@@ -50,8 +50,8 @@ module TableDisplay
 
     # also add any :methods given to the list
     extra_entries.each {|name| column_lengths[name] = 0}
-    
-    data = collect do |record|
+
+    data = target.collect do |record|
       # add the values for all the columns in our list in order they are
       column_lengths.collect do |attribute, max_width|
         value = if attribute.respond_to?(:call)
@@ -66,25 +66,25 @@ module TableDisplay
         value.is_a?(Numeric) ? value : string_value # keep Numeric values as-is for now, so we can handle them specially in the output below
       end
     end
-    
+
     return [] if data.empty?
-    
+
     # build the table header
     separator_string = "+"
     heading_string   = "|"
     column_lengths.each do |attribute, max_width|
       next unless max_width > 0 # skip any columns we never actually saw
       name = (attribute.respond_to?(:name) ? attribute.name : attribute).to_s
-      
+
       # the column needs to fit the column header as well as the values
       if name.mb_chars.length > max_width
         column_lengths[attribute] = max_width = name.mb_chars.length
       end
-      
+
       separator_string << '-'*(max_width + 2) << '+'
       heading_string   << ' ' << name.ljust(max_width) << ' |'
     end
-    
+
     rows = [separator_string, heading_string, separator_string]
     data.each do |data_row|
       data_string = "|"
@@ -105,15 +105,12 @@ end
 
 module Kernel
   def pt(target, *options)
-    puts target.respond_to?(:to_table_display) ? target.to_table_display(*options) : target
+    puts collection?(target) ? TableDisplay.to_table_display(target, *options) : target
+  end
+
+  private
+
+  def collection?(target)
+    target.respond_to?(:each) && target.respond_to?(:collect)
   end
 end
-
-# all Enumerable classes should get TableDisplay functionality...
-Enumerable.send(:include, TableDisplay)
-
-# including those that have already included Enumerable by the time this plugin is loaded.
-# Ruby doesn't recursively update through the module tree, so although any new classes/modules
-# that include Enumerable will get TableDisplay, we have to do it ourself for older ones.
-ObjectSpace.each_object(Module) {|o| o.send(:include, TableDisplay) if o.ancestors.include?(Enumerable)}
-ObjectSpace.each_object(Class)  {|o| o.send(:include, TableDisplay) if o.ancestors.include?(Enumerable)}

--- a/table_display.gemspec
+++ b/table_display.gemspec
@@ -22,7 +22,6 @@ The normal output uses #inspect on the data values to make them printable, so yo
 see what type the values had.  When that's inconvenient or you'd prefer direct display,
 you can pass the option :inspect => false to disable inspection.
 EOF
-  gem.has_rdoc     = false
   gem.author       = "Will Bryant"
   gem.email        = "will.bryant@gmail.com"
   gem.homepage     = "http://github.com/willbryant/table_display"

--- a/test/table_display_test.rb
+++ b/test/table_display_test.rb
@@ -8,7 +8,7 @@ class Time
     return to_formatted_s(*args) unless args.empty?
     strftime("%Y-%m-%d %H:%M:%S %z")
   end
-  
+
   def inspect
     to_s
   end
@@ -20,13 +20,13 @@ end
 
 class Task < ActiveRecord::Base
   belongs_to :project
-  
+
   scope :completed, -> { where('completed_at IS NOT NULL') }
-  
+
   def completed?
     !completed_at.nil?
   end
-  
+
   def project_name
     project.name
   end
@@ -34,45 +34,45 @@ end
 
 class TableDisplayTest < ActiveSupport::TestCase
   fixtures :all
-  
+
   def setup
     @project = projects(:this_project)
   end
-  
-  test "#to_table_display is available on arrays" do
+
+  test "#to_table_display works on arrays" do
     assert_nothing_raised do
-      [].to_table_display
+      TableDisplay.to_table_display([])
     end
   end
-  
-  test "#to_table_display is available on ActiveRecord find results" do # which should be arrays, in fact
+
+  test "#to_table_display works on ActiveRecord find results" do # which should be arrays, in fact
     assert_nothing_raised do
-      Task.all.to_table_display
+      TableDisplay.to_table_display(Task.all)
     end
   end
-  
-  test "#to_table_display is available on ActiveRecord named_scopes" do
+
+  test "#to_table_display works on ActiveRecord named_scopes" do
     assert_nothing_raised do
-      Task.completed.to_table_display
-    end      
+      TableDisplay.to_table_display(Task.completed)
+    end
   end
-  
-  test "#to_table_display is available on ActiveRecord association collections" do
+
+  test "#to_table_display works on ActiveRecord association collections" do
     assert_nothing_raised do
-      @project.tasks.to_table_display
-    end      
+      TableDisplay.to_table_display(@project.tasks)
+    end
   end
-  
-  test "#to_table_display is available on named scopes in ActiveRecord association collections" do
+
+  test "#to_table_display works on named scopes in ActiveRecord association collections" do
     assert_nothing_raised do
-      @project.tasks.completed.to_table_display
-    end      
+      TableDisplay.to_table_display(@project.tasks.completed)
+    end
   end
-  
+
   # we run some simple regression tests to check that everything works as expected
-  
+
   test "#to_table_display by default includes all the database columns in database order" do
-    assert_equal <<END.strip, @project.tasks.to_table_display.join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks).join("\n")
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
 | id | project_id | description            | due_on           | completed_at              | created_at                | updated_at                |
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
@@ -81,9 +81,9 @@ class TableDisplayTest < ActiveSupport::TestCase
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
 END
   end
-  
+
   test "#to_table_display by default includes all the database columns in database order even when not called on a typeless array" do
-    assert_equal <<END.strip, @project.tasks.all.to_table_display.join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks.all).join("\n")
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
 | id | project_id | description            | due_on           | completed_at              | created_at                | updated_at                |
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
@@ -92,9 +92,9 @@ END
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+
 END
   end
-  
+
   test "#to_table_display leaves out any attributes not loaded" do
-    assert_equal <<END.strip, @project.tasks.select("id, project_id, completed_at").to_table_display.join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks.select("id, project_id, completed_at")).join("\n")
 +----+------------+---------------------------+
 | id | project_id | completed_at              |
 +----+------------+---------------------------+
@@ -105,7 +105,8 @@ END
   end
 
   test "#to_table_display also shows any attributes that are not columns on the underlying table" do
-    assert_equal <<END.strip, @project.tasks.joins(:project).select("tasks.id, project_id, projects.description AS BigProjectDescription").to_table_display.join("\n")
+    with_transient_attributes = @project.tasks.joins(:project).select("tasks.id, project_id, projects.description AS BigProjectDescription")
+    assert_equal <<END.strip, TableDisplay.to_table_display(with_transient_attributes).join("\n")
 +----+------------+-----------------------------------------------------------------------------------------------------+
 | id | project_id | BigProjectDescription                                                                               |
 +----+------------+-----------------------------------------------------------------------------------------------------+
@@ -114,9 +115,9 @@ END
 +----+------------+-----------------------------------------------------------------------------------------------------+
 END
   end
-  
+
   test "#to_table_display excludes any columns named in :except" do
-    assert_equal <<END.strip, @project.tasks.to_table_display(:except => ['created_at', :completed_at]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :except => ['created_at', :completed_at]).join("\n")
 +----+------------+------------------------+------------------+---------------------------+
 | id | project_id | description            | due_on           | updated_at                |
 +----+------------+------------------------+------------------+---------------------------+
@@ -125,9 +126,9 @@ END
 +----+------------+------------------------+------------------+---------------------------+
 END
   end
-  
+
   test "#to_table_display excludes all columns except those named in :only" do
-    assert_equal <<END.strip, @project.tasks.to_table_display(:only => ['id', :due_on]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :only => ['id', :due_on]).join("\n")
 +----+------------------+
 | id | due_on           |
 +----+------------------+
@@ -136,9 +137,9 @@ END
 +----+------------------+
 END
   end
-  
+
   test "#to_table_display keeps the columns in the order given in :only" do
-    assert_equal <<END.strip, @project.tasks.to_table_display(:only => [:due_on, 'id']).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :only => [:due_on, 'id']).join("\n")
 +------------------+----+
 | due_on           | id |
 +------------------+----+
@@ -146,7 +147,7 @@ END
 | Sun, 05 Apr 2009 |  2 |
 +------------------+----+
 END
-    assert_equal <<END.strip, @project.tasks.to_table_display(:only => [:due_on, :id]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :only => [:due_on, :id]).join("\n")
 +------------------+----+
 | due_on           | id |
 +------------------+----+
@@ -155,9 +156,9 @@ END
 +------------------+----+
 END
   end
-  
+
   test "#to_table_display accepts an unnamed list of arguments for column names" do
-    assert_equal <<END.strip, @project.tasks.to_table_display('id', :due_on, :completed?).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, 'id', :due_on, :completed?).join("\n")
 +----+------------------+------------+
 | id | due_on           | completed? |
 +----+------------------+------------+
@@ -166,9 +167,9 @@ END
 +----+------------------+------------+
 END
   end
-  
+
   test "#to_table_display allows auxiliary named arguments with the array format" do
-    assert_equal <<END.strip, @project.tasks.to_table_display('id', :due_on, :completed?, :inspect => false).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, 'id', :due_on, :completed?, :inspect => false).join("\n")
 +----+------------+------------+
 | id | due_on     | completed? |
 +----+------------+------------+
@@ -177,9 +178,9 @@ END
 +----+------------+------------+
 END
   end
-  
+
   test "#to_table_display also shows any :methods given as columns" do
-    assert_equal <<END.strip, @project.tasks.to_table_display(:methods => [:completed?, 'project_name']).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :methods => [:completed?, 'project_name']).join("\n")
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+------------+------------------------+
 | id | project_id | description            | due_on           | completed_at              | created_at                | updated_at                | completed? | project_name           |
 +----+------------+------------------------+------------------+---------------------------+---------------------------+---------------------------+------------+------------------------+
@@ -195,7 +196,7 @@ END
       object.define_singleton_method(:call) { |record| "(id #{record.id})" }
     end
 
-    assert_equal <<END.strip, @project.tasks.to_table_display('id', :due_on, :completed?, named_callable).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, 'id', :due_on, :completed?, named_callable).join("\n")
 +----+------------------+------------+----------+
 | id | due_on           | completed? | sample   |
 +----+------------------+------------+----------+
@@ -216,7 +217,7 @@ END
     due_on_proc = -> (record) { record.due_on }
     due_on_proc.define_singleton_method(:to_s) { "due_on_proc" }
 
-    assert_equal <<END.strip, @project.tasks.to_table_display('id', due_on_proc, instrument.method(:creation), callable).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, 'id', due_on_proc, instrument.method(:creation), callable).join("\n")
 +----+------------------+----------------+----------------+
 | id | due_on_proc      | creation       | arbitrary to_s |
 +----+------------------+----------------+----------------+
@@ -227,7 +228,7 @@ END
   end
 
   test "#to_table_display shows the #to_s format rather than the #inspect format when :inspect => false is set" do
-    assert_equal <<END.strip, @project.tasks.to_table_display(:inspect => false).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :inspect => false).join("\n")
 +----+------------+----------------------+------------+---------------------------+---------------------------+---------------------------+
 | id | project_id | description          | due_on     | completed_at              | created_at                | updated_at                |
 +----+------------+----------------------+------------+---------------------------+---------------------------+---------------------------+
@@ -237,10 +238,10 @@ END
 END
     # note the strings no longer have quotes, the nil is not shown, and the date format happens to be different
   end
-  
+
   test "#to_table_display correctly pads out to match the length in characters of long values with utf-8 sequences" do
     tasks(:write_a_handy_plugin).update_attribute(:description, "Write a handy plugin \342\200\223 with UTF-8 handling")
-    assert_equal <<END.strip, @project.tasks.to_table_display(:only => [:id, :description], :inspect => false).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :only => [:id, :description], :inspect => false).join("\n")
 +----+--------------------------------------------+
 | id | description                                |
 +----+--------------------------------------------+
@@ -252,7 +253,7 @@ END
 
   test "#to_table_display correctly pads out short values with utf-8 sequences" do
     tasks(:blog_the_plugin).update_attribute(:description, "Blog \342\200\223 plugin")
-    assert_equal <<END.strip, @project.tasks.to_table_display(:only => [:id, :description], :inspect => false).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@project.tasks, :only => [:id, :description], :inspect => false).join("\n")
 +----+----------------------+
 | id | description          |
 +----+----------------------+
@@ -263,17 +264,17 @@ END
   end
 
   test "#to_table_display on an empty array returns an empty result" do
-    assert_equal [], [].to_table_display
+    assert_equal [], TableDisplay.to_table_display([])
   end
-  
+
   test "#to_table_display can extract data out of raw hashes" do
     @records = [{:foo => 1234, :bar => "test"},
                 {:bar => "text", :baz => 5678}]
-    results = @records.to_table_display.join("\n")
+    results = TableDisplay.to_table_display(@records).join("\n")
     assert results.include?('| foo  |')
     assert results.include?('| bar    |')
     assert results.include?('| baz  |')
-    assert_equal <<END.strip, @records.to_table_display(:only => [:foo, :bar, :baz]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :only => [:foo, :bar, :baz]).join("\n")
 +------+--------+------+
 | foo  | bar    | baz  |
 +------+--------+------+
@@ -281,7 +282,7 @@ END
 | nil  | "text" | 5678 |
 +------+--------+------+
 END
-    assert_equal <<END.strip, @records.to_table_display(:only => [:bar, :baz]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :only => [:bar, :baz]).join("\n")
 +--------+------+
 | bar    | baz  |
 +--------+------+
@@ -289,7 +290,7 @@ END
 | "text" | 5678 |
 +--------+------+
 END
-    assert_equal <<END.strip, @records.to_table_display(:except => [:bar]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :except => [:bar]).join("\n")
 +------+------+
 | foo  | baz  |
 +------+------+
@@ -298,15 +299,15 @@ END
 +------+------+
 END
   end
-  
+
   test "#to_table_display can extract data out of OpenStruct records" do
     @records = [OpenStruct.new(:foo => 1234, :bar => "test"),
                 OpenStruct.new(:bar => "text", :baz => 5678)]
-    results = @records.to_table_display.join("\n")
+    results = TableDisplay.to_table_display(@records).join("\n")
     assert results.include?('| foo  |')
     assert results.include?('| bar    |')
     assert results.include?('| baz  |')
-    assert_equal <<END.strip, @records.to_table_display(:only => [:foo, :bar, :baz]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :only => [:foo, :bar, :baz]).join("\n")
 +------+--------+------+
 | foo  | bar    | baz  |
 +------+--------+------+
@@ -314,7 +315,7 @@ END
 | nil  | "text" | 5678 |
 +------+--------+------+
 END
-    assert_equal <<END.strip, @records.to_table_display(:only => [:bar, :baz]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :only => [:bar, :baz]).join("\n")
 +--------+------+
 | bar    | baz  |
 +--------+------+
@@ -322,7 +323,7 @@ END
 | "text" | 5678 |
 +--------+------+
 END
-    assert_equal <<END.strip, @records.to_table_display(:except => [:bar]).join("\n")
+    assert_equal <<END.strip, TableDisplay.to_table_display(@records, :except => [:bar]).join("\n")
 +------+------+
 | foo  | baz  |
 +------+------+


### PR DESCRIPTION
Remove the need for TableDisplay to be included in Enumerable and its descendants.
Remove the requirement to call `send(:include, TableDisplay)`.